### PR TITLE
Hide set as default for current default dashboard

### DIFF
--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -491,13 +491,25 @@ export default function App() {
 
         <div style={{ display: 'grid', gap: 12 }} ref={gridWrapRef}>
           <div className="section-title">Dashboard {version && <span className="chip" style={{ marginLeft: 8 }}>v{version}</span>}
-            <button className="btn btn-sm" style={{ marginLeft: 'auto', background: '#239BA7', color: '#fff', borderColor: '#239BA7' }} onClick={async () => {
-              try {
-                const list = await api.listDashboards()
-                const current = list.find((d:any) => d.name === dashboardName && d.version === version)
-                if (current?.id) { await api.setDefaultDashboard(current.id); toast('success','Set as default dashboard') } else { toast('error','Save first') }
-              } catch(e:any){ toast('error', e?.message||'Failed') }
-            }}>Default</button>
+            {(() => {
+              const current = dashList.find((d:any) => d.name === dashboardName && d.version === version)
+              if (current?.default_flag) {
+                return <span className="badge" style={{ marginLeft: 'auto', background: 'var(--primary)', color: '#fff' }}>Default Dashboard</span>
+              } else {
+                return <button className="btn btn-sm" style={{ marginLeft: 'auto', background: '#239BA7', color: '#fff', borderColor: '#239BA7' }} onClick={async () => {
+                  try {
+                    if (current?.id) { 
+                      await api.setDefaultDashboard(current.id); 
+                      toast('success','Set as default dashboard')
+                      // Refresh dashboard list to update default flags
+                      await api.listDashboards().then(setDashList)
+                    } else { 
+                      toast('error','Save first') 
+                    }
+                  } catch(e:any){ toast('error', e?.message||'Failed') }
+                }}>Set as Default</button>
+              }
+            })()}
           </div>
 
           <div className="tabs-bar">


### PR DESCRIPTION
Replace 'Set as Default' button with 'Default Dashboard' badge when the current dashboard is already default.

Previously, the dashboard section allowed users to attempt to set an already default dashboard as default, leading to a confusing user experience. This change ensures that the 'Set as Default' button is only shown when applicable, aligning its behavior with the TopBar component and providing a clearer indication of the dashboard's default status.

---
<a href="https://cursor.com/background-agent?bcId=bc-e422346e-672c-4a9a-a69b-d6c8cd8fa47e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e422346e-672c-4a9a-a69b-d6c8cd8fa47e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

