### PR TITLE
Fix KPI generation division by zero errors

### DIFF
--- a/backend/app/kpi.py
+++ b/backend/app/kpi.py
@@ -21,6 +21,7 @@ SYSTEM_PROMPT_TEMPLATE = (
     "- The SQL MUST return columns aliased exactly as required by expected_schema: for timeseries use x,y; for categorical use label,value; for distribution use label,value.\n"
     "- Only reference columns that exist in the provided schema. Use exact column names (case-sensitive as listed). If a desired KPI is not feasible with the schema, skip it.\n"
     "- Prefer efficient queries. Use COALESCE to handle NULLs. Use LIMIT for categorical Top-N (e.g., 10). Avoid SELECT *.\n"
+    "- Always use SAFE_DIVIDE(numerator, denominator) for any ratio or percentage; never use bare '/' division. This prevents division-by-zero errors.\n"
     "- If a date or timestamp column exists, include at least two time-series KPIs that show trend and growth.\n"
     "- If numeric measures exist, include growth/velocity (MoM/YoY) and rolling averages (e.g., 7d/28d).\n"
     "- If categorical dimensions exist, include contribution mix (Top-N by value) and concentration (share of top categories).\n"
@@ -53,6 +54,7 @@ CROSS_SYSTEM_PROMPT_TEMPLATE = (
     "- Only JOIN when a valid key exists in both tables (e.g., *_id, id, keys with matching semantics).\n"
     "- Ensure SQL aliases match expected_schema: timeseries -> x,y; categorical -> label,value; distribution -> label,value.\n"
     "- Prefer efficient aggregations; avoid SELECT *. Use COALESCE for NULLs.\n"
+    "- Always use SAFE_DIVIDE(numerator, denominator) for ratios/percentages; never use bare '/' division.\n"
     "- If time columns exist, create trend and growth KPIs. Otherwise focus on categorical contribution and distributions.\n\n"
     "Examples to consider (only if schema supports them):\n"
     "- Revenue (or key measure) by product/category/region/channel (JOIN fact to dimension).\n"
@@ -337,7 +339,7 @@ class KPIService:
                 "For categorical: columns should be label (STRING) and value (NUMBER). "
                 "For distribution: columns should be label and value. "
                 "Use table references exactly as `project.dataset.table`. "
-                "Keep SQL simple and efficient. Use safe handling for NULLs."
+                "Keep SQL simple and efficient. Use safe handling for NULLs. Always use SAFE_DIVIDE(numerator, denominator) for ratios/percentages to avoid division-by-zero; never use bare '/' division."
             )
             
             # Build user prompt

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -188,16 +188,34 @@ def run_kpi(req: RunKpiRequest):
 			if col and val is not None:
 				where_clauses.append(f"{col} = @catValue")
 				params.append(bigquery.ScalarQueryParameter("catValue", "STRING", str(val)))
-		if where_clauses:
-			wrapped = f"SELECT * FROM ( {sql} ) WHERE " + " AND ".join(where_clauses)
-			job_config = bigquery.QueryJobConfig(query_parameters=params)
-			rows_iter = bq_service.client.query(wrapped, job_config=job_config, location=bq_service.location)
-			result_rows = [dict(r) for r in rows_iter]
-			# normalize
-			norm = [ { k: bq_service._normalize_value(v) for k, v in r.items() } for r in result_rows ]
-			return {"rows": norm}
-		rows = bq_service.query_rows(sql)
-		return {"rows": rows}
+		# Helper to run query (with optional WHERE wrapper)
+		def _run_query(q: str):
+			if where_clauses:
+				wrapped = f"SELECT * FROM ( {q} ) WHERE " + " AND ".join(where_clauses)
+				job_config = bigquery.QueryJobConfig(query_parameters=params)
+				rows_iter = bq_service.client.query(wrapped, job_config=job_config, location=bq_service.location)
+				result_rows = [dict(r) for r in rows_iter]
+				return [ { k: bq_service._normalize_value(v) for k, v in r.items() } for r in result_rows ]
+			rows = bq_service.query_rows(q)
+			return rows
+		# First attempt
+		try:
+			rows = _run_query(sql)
+			return {"rows": rows}
+		except Exception as inner_exc:
+			msg = str(inner_exc).lower()
+			# BigQuery division-by-zero errors may mention divide by zero / invalid / safe divide
+			if "divide by zero" in msg or "division by zero" in msg:
+				try:
+					# Ask LLM to rewrite with SAFE_DIVIDE while preserving schema/aliases
+					fixed_sql = kpi_service.llm.edit_sql(sql, "Rewrite to use SAFE_DIVIDE for all divisions; preserve output columns and aliases.")
+					rows = _run_query(fixed_sql)
+					return {"rows": rows}
+				except Exception:
+					# Fall through to raise original error if retry fails
+					pass
+			# If not a divide-by-zero or retry failed, rethrow the original
+			raise inner_exc
 	except Exception as exc:
 		raise HTTPException(status_code=400, detail=str(exc))
 


### PR DESCRIPTION
Update KPI generation to use SAFE_DIVIDE and add a runtime fallback to prevent divide-by-zero errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bef6a0a-ab2d-414a-a86d-435f269d2b7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bef6a0a-ab2d-414a-a86d-435f269d2b7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

