### PR TITLE
Investigate backend dataset visibility in dropdown

### DIFF
--- a/backend/app/bq.py
+++ b/backend/app/bq.py
@@ -93,12 +93,15 @@ class BigQueryService:
                     ds.dataset_id.startswith('test_')
                 )
             
+            # Skip backend-created datasets entirely
+            if is_backend_created:
+                continue
+            
             datasets.append(
                 {
                     "datasetId": ds.dataset_id,
                     "friendlyName": None,
                     "description": None,
-                    "isBackendCreated": is_backend_created,
                 }
             )
         return datasets


### PR DESCRIPTION
Filter out backend-created datasets directly in `list_datasets` to prevent them from appearing in the UI dropdown.

The `list_datasets` API previously included an `isBackendCreated` flag, but this flag was stripped by the `response_model` in FastAPI, making the frontend's filter ineffective. This change moves the filtering logic to the backend, ensuring that the API only returns user-facing datasets and resolves the issue of backend datasets appearing in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5793ae8-bbad-4a90-9415-8f8f2faf0dbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5793ae8-bbad-4a90-9415-8f8f2faf0dbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

