### PR TITLE
Rebuild lineage graph ui with d3 sankey

### DIFF
--- a/backend/app/lineage.py
+++ b/backend/app/lineage.py
@@ -221,6 +221,13 @@ def compute_lineage(sql: str, dialect: str = "bigquery") -> Dict[str, Any]:
     sources = _collect_tables(qualified)
     alias_map = _build_alias_map(qualified, sources)
     joins = _join_details(qualified)
+    # Assign stable join IDs if missing so frontend can label JOIN nodes consistently
+    try:
+        for i, j in enumerate(joins):
+            if not isinstance(j.get("id", None), str) or not j.get("id"):
+                j["id"] = f"J{i+1}"
+    except Exception:
+        pass
     filters = _collect_filters(qualified)
     group_by = _collect_group_by(qualified)
     outputs = _collect_outputs(qualified)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "1.7.2",
         "d3": "7.9.0",
+        "d3-sankey": "^0.12.3",
         "html2canvas": "1.4.1",
         "jspdf": "2.5.2",
         "react": "18.3.1",
@@ -1861,6 +1862,46 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,28 +9,29 @@
     "preview": "vite preview --port 5173"
   },
   "dependencies": {
+    "axios": "1.7.2",
+    "d3": "7.9.0",
+    "d3-sankey": "^0.12.3",
+    "html2canvas": "1.4.1",
+    "jspdf": "2.5.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "d3": "7.9.0",
-    "axios": "1.7.2",
     "react-grid-layout": "1.4.4",
+    "react-markdown": "9.0.0",
     "react-resizable": "3.0.5",
+    "react-router-dom": "6",
+    "react-syntax-highlighter": "15.5.0",
+    "remark-gfm": "4.0.0",
     "vega": "5.30.0",
     "vega-embed": "6.26.0",
-    "vega-lite": "5.21.0",
-    "react-markdown": "9.0.0",
-    "remark-gfm": "4.0.0",
-    "react-syntax-highlighter": "15.5.0",
-    "react-router-dom": "6",
-    "html2canvas": "1.4.1",
-    "jspdf": "2.5.2"
+    "vega-lite": "5.21.0"
   },
   "devDependencies": {
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "typescript": "5.5.3",
-    "vite": "5.4.1",
+    "@types/react-grid-layout": "1.3.5",
     "@vitejs/plugin-react": "4.3.1",
-    "@types/react-grid-layout": "1.3.5"
+    "typescript": "5.5.3",
+    "vite": "5.4.1"
   }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -947,7 +947,7 @@ export default function Home() {
                   <div style={{ padding: 16, color: 'var(--danger)' }}>Failed to load lineage: {lineageError}</div>
                 ) : (
                   <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-                    <LineageGraph graph={(lineageData && lineageData.graph) || { nodes: [], edges: [] }} />
+                    <LineageGraph graph={(lineageData && lineageData.graph) || { nodes: [], edges: [] }} joins={(lineageData && lineageData.joins) || []} />
                   </div>
                 )}
               </div>

--- a/frontend/src/ui/LineageGraph.tsx
+++ b/frontend/src/ui/LineageGraph.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react'
 import * as d3 from 'd3'
+import { sankey as d3Sankey, sankeyLinkHorizontal, sankeyJustify } from 'd3-sankey'
 
-type GraphNode = { id: string; type: 'table' | 'column' | 'output'; label?: string }
-type GraphEdge = { source: string; target: string; type: 'join' | 'join_table' | 'projection' }
+type GraphNode = { id: string; type: 'table' | 'column' | 'output' | 'join'; label?: string }
+type GraphEdge = { source: string; target: string; type: 'join' | 'join_table' | 'projection' | 'contains' | 'derives' }
 
-export function LineageGraph({ graph }: { graph: { nodes: GraphNode[]; edges: GraphEdge[] } }) {
+type JoinInfo = { left_table?: string; right_table?: string; type?: string; on?: string; pairs?: { left: string; right: string }[] }
+
+export function LineageGraph({ graph, joins }: { graph: { nodes: GraphNode[]; edges: GraphEdge[] }; joins?: JoinInfo[] }) {
   const wrapRef = useRef<HTMLDivElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [size, setSize] = useState<{ w: number; h: number }>({ w: 800, h: 480 })
@@ -27,65 +30,150 @@ export function LineageGraph({ graph }: { graph: { nodes: GraphNode[]; edges: Gr
 
     const g = svg.append('g')
 
-    const zoom = d3.zoom<SVGSVGElement, unknown>().scaleExtent([0.2, 4]).on('zoom', (event) => {
+    const zoom = d3.zoom<SVGSVGElement, unknown>().scaleExtent([0.3, 4]).on('zoom', (event) => {
       g.attr('transform', String(event.transform))
     })
     svg.call(zoom as any)
 
-    const color = (d: GraphNode) => d.type === 'table' ? '#239BA7' : d.type === 'output' ? '#8B5CF6' : '#64748B'
-    const radius = (d: GraphNode) => d.type === 'table' ? 16 : d.type === 'output' ? 12 : 8
+    const color = (d: GraphNode) => d.type === 'table' ? '#239BA7' : d.type === 'output' ? '#8B5CF6' : d.type === 'join' ? '#F59E0B' : '#64748B'
 
-    const nodes: any[] = graph.nodes.map(n => ({ ...n }))
-    const nodeById = new Map(nodes.map(n => [n.id, n]))
-    const links: any[] = graph.edges.map(e => ({ ...e, source: nodeById.get(e.source), target: nodeById.get(e.target) })).filter(l => l.source && l.target)
+    // 1 inch spacing ~ 96 px
+    const NODE_PADDING = 96
+    const NODE_WIDTH = 16
+    const MARGIN = { top: 8, right: 8, bottom: 8, left: 8 }
 
-    const sim = d3.forceSimulation(nodes)
-      .force('link', d3.forceLink(links).id((d: any) => d.id).distance((l: any) => l.type === 'join_table' ? 120 : 60))
-      .force('charge', d3.forceManyBody().strength(-280))
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide().radius((d: any) => radius(d) + 10))
+    // Build nodes and links tailored for Sankey
+    const baseNodes: Record<string, GraphNode> = {}
+    for (const n of graph.nodes || []) {
+      baseNodes[n.id] = { ...n }
+      if (!baseNodes[n.id].label) {
+        baseNodes[n.id].label = n.type === 'table' ? (n.label || n.id.split('.').slice(-1)[0]) : (n.label || n.id)
+      }
+    }
 
-    const link = g.append('g').attr('stroke', '#999').attr('stroke-opacity', 0.6)
-      .selectAll('line')
-      .data(links)
-      .enter().append('line')
-      .attr('stroke-width', (d: any) => d.type === 'join_table' ? 2.4 : 1.4)
-      .attr('stroke-dasharray', (d: any) => d.type === 'projection' ? '4 2' : null)
+    // Compute output dependencies by table to help route join -> outputs
+    const outputs = new Set<string>((graph.nodes || []).filter(n => n.type === 'output').map(n => n.id))
+    const derivesEdges = (graph.edges || []).filter(e => e.type === 'derives')
+    const outputsByTable: Record<string, Set<string>> = {}
+    for (const e of derivesEdges) {
+      if (!outputs.has(e.target)) continue
+      outputsByTable[e.source] = outputsByTable[e.source] || new Set<string>()
+      outputsByTable[e.source].add(e.target)
+    }
 
-    const node = g.append('g').selectAll('g').data(nodes).enter().append('g').call(d3.drag<SVGGElement, any>()
-      .on('start', (event, d: any) => { if (!event.active) sim.alphaTarget(0.3).restart(); d.fx = d.x; d.fy = d.y })
-      .on('drag', (event, d: any) => { d.fx = event.x; d.fy = event.y })
-      .on('end', (event, d: any) => { if (!event.active) sim.alphaTarget(0); d.fx = null; d.fy = null })
-    )
+    // Create join nodes and corresponding links
+    const joinNodeIds: string[] = []
+    const syntheticJoinLinks: { source: string; target: string; type: 'join_in' | 'join_out'; meta?: any }[] = []
+    const effectiveJoins = Array.isArray(joins) ? joins : []
+    for (let idx = 0; idx < effectiveJoins.length; idx++) {
+      const j = effectiveJoins[idx]
+      const joinId = `__join__${idx + 1}`
+      const joinLabel = `JOIN ${idx + 1}`
+      baseNodes[joinId] = { id: joinId, type: 'join', label: joinLabel }
+      joinNodeIds.push(joinId)
 
-    node.append('circle')
-      .attr('r', (d: any) => radius(d))
-      .attr('fill', (d: any) => color(d))
+      const lt = j.left_table || ''
+      const rt = j.right_table || ''
+      if (lt) syntheticJoinLinks.push({ source: lt, target: joinId, type: 'join_in', meta: { on: j.on, side: 'left' } })
+      if (rt) syntheticJoinLinks.push({ source: rt, target: joinId, type: 'join_in', meta: { on: j.on, side: 'right' } })
+
+      // Route join -> outputs where either side contributes
+      const contributingOutputs = new Set<string>()
+      if (lt && outputsByTable[lt]) outputsByTable[lt].forEach(o => contributingOutputs.add(o))
+      if (rt && outputsByTable[rt]) outputsByTable[rt].forEach(o => contributingOutputs.add(o))
+      contributingOutputs.forEach(o => syntheticJoinLinks.push({ source: joinId, target: o, type: 'join_out', meta: { on: j.on } }))
+    }
+
+    // Build remaining links from graph
+    const allowedEdgeTypes = new Set(['contains', 'projection', 'derives'])
+    const rawLinks: { source: string; target: string; type: string; meta?: any }[] = []
+    for (const e of graph.edges || []) {
+      if (!allowedEdgeTypes.has(e.type)) continue
+      rawLinks.push({ source: e.source, target: e.target, type: e.type })
+    }
+
+    // Merge synthetic join links
+    rawLinks.push(...syntheticJoinLinks)
+
+    // Filter out isolated nodes (keep only nodes that appear in any link)
+    const usedIds = new Set<string>()
+    for (const l of rawLinks) { usedIds.add(l.source); usedIds.add(l.target) }
+    const nodes = Object.values(baseNodes).filter(n => usedIds.has(n.id))
+
+    // Map node id -> index
+    const idToIndex = new Map<string, number>(nodes.map((n, i) => [n.id, i]))
+
+    // Convert links to index-based for sankey
+    const links = rawLinks
+      .filter(l => idToIndex.has(l.source) && idToIndex.has(l.target))
+      .map(l => ({ source: idToIndex.get(l.source) as number, target: idToIndex.get(l.target) as number, value: 1, _type: l.type, _meta: l.meta }))
+
+    // Prepare sankey layout
+    const sankeyLayout = d3Sankey<any, any>()
+      .nodeId((d: any) => d.id)
+      .nodeWidth(NODE_WIDTH)
+      .nodePadding(NODE_PADDING)
+      .nodeAlign(sankeyJustify)
+      .extent([[MARGIN.left, MARGIN.top], [width - MARGIN.right, height - MARGIN.bottom]])
+
+    const sankeyData = sankeyLayout({
+      nodes: nodes.map(d => ({ ...d })),
+      links: links.map(l => ({ ...l }))
+    }) as unknown as { nodes: (GraphNode & { x0: number; x1: number; y0: number; y1: number })[]; links: any[] }
+
+    // Draw links
+    const link = g.append('g')
+      .attr('fill', 'none')
+      .attr('stroke-opacity', 0.4)
+      .selectAll('path')
+      .data(sankeyData.links)
+      .enter()
+      .append('path')
+      .attr('d', sankeyLinkHorizontal())
+      .attr('stroke', (d: any) => {
+        const t = d._type
+        if (t === 'projection') return '#94a3b8'
+        if (t === 'contains') return '#38bdf8'
+        if (t === 'join_in' || t === 'join_out') return '#f59e0b'
+        if (t === 'derives') return '#22c55e'
+        return '#999'
+      })
+      .attr('stroke-width', (d: any) => Math.max(1, d.width))
+      .attr('stroke-linecap', 'round')
+
+    link.append('title').text((d: any) => `${nodes[d.source.index].label || nodes[d.source.index].id} → ${nodes[d.target.index].label || nodes[d.target.index].id}`)
+
+    // Draw nodes
+    const node = g.append('g')
+      .selectAll('g')
+      .data(sankeyData.nodes)
+      .enter()
+      .append('g')
+
+    node.append('rect')
+      .attr('x', (d: any) => d.x0)
+      .attr('y', (d: any) => d.y0)
+      .attr('height', (d: any) => Math.max(2, d.y1 - d.y0))
+      .attr('width', (d: any) => Math.max(4, d.x1 - d.x0))
+      .attr('fill', (d: any) => color(d as GraphNode))
       .attr('stroke', '#fff')
-      .attr('stroke-width', 1.5)
+      .attr('stroke-width', 1)
 
     node.append('title').text((d: any) => d.id)
 
+    // Labels: to the right of the node
     node.append('text')
-      .text((d: any) => d.label || d.id.split('.').slice(-1)[0])
-      .attr('x', 10)
-      .attr('y', 4)
+      .attr('x', (d: any) => d.x1 + 8)
+      .attr('y', (d: any) => (d.y0 + d.y1) / 2)
+      .attr('dy', '0.35em')
       .attr('font-size', 11)
       .attr('fill', 'currentColor')
-
-    sim.on('tick', () => {
-      link
-        .attr('x1', (d: any) => d.source.x)
-        .attr('y1', (d: any) => d.source.y)
-        .attr('x2', (d: any) => d.target.x)
-        .attr('y2', (d: any) => d.target.y)
-
-      node.attr('transform', (d: any) => `translate(${d.x},${d.y})`)
-    })
+      .text((d: any) => d.label || (d.type === 'table' ? d.id.split('.').slice(-1)[0] : d.id))
+      .style('pointer-events', 'none')
 
     // Fit to view on first render
     setTimeout(() => {
-      const bounds = g.node()?.getBBox()
+      const bounds = (g.node() as SVGGElement | null)?.getBBox()
       if (bounds && isFinite(bounds.width) && isFinite(bounds.height) && bounds.width > 0 && bounds.height > 0) {
         const wScale = Math.max(0.3, Math.min(1.2, 0.9 * width / bounds.width))
         const hScale = Math.max(0.3, Math.min(1.2, 0.9 * height / bounds.height))
@@ -95,7 +183,7 @@ export function LineageGraph({ graph }: { graph: { nodes: GraphNode[]; edges: Gr
         svg.transition().duration(350).call(zoom.transform as any, d3.zoomIdentity.translate(tx, ty).scale(scale))
       }
     }, 0)
-  }, [graph, size.w, size.h])
+  }, [graph, joins, size.w, size.h])
 
   return (
     <div ref={wrapRef} style={{ width: '100%', height: '100%' }}>


### PR DESCRIPTION
Rebuild the Lineage graph UI using D3 Sankey to improve the visualization of data flow and dependencies.

The existing force-directed graph in `LineageGraph.tsx` has been replaced with a D3 Sankey diagram, fulfilling the user's request for a clearer left-to-right flow visualization. This includes explicit join nodes, ~1-inch node spacing, labels for all nodes, filtering of isolated nodes, and pan/zoom functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-549477e5-1dc2-4d31-9252-b4261ac21977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-549477e5-1dc2-4d31-9252-b4261ac21977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

