### PR TITLE
Propose kpis instead of drafting them

### DIFF
--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -222,9 +222,9 @@ export default function App() {
     try {
       await api.prepare(selected, 5)
       const kpisResp = await api.generateKpis(selected, 5, preferCross)
-      try { sessionStorage.setItem('kpiDrafts', JSON.stringify({ drafts: kpisResp, selectedTables: selected })) } catch {}
-      toast('success', `Generated ${kpisResp.length} KPIs. Review and publish from KPI Draft.`)
-      navigate('/kpi-draft', { state: { drafts: kpisResp, selectedTables: selected } })
+      try { sessionStorage.setItem('kpiDrafts', JSON.stringify({ drafts: [], proposals: kpisResp, selectedTables: selected })) } catch {}
+      toast('success', `Generated ${kpisResp.length} KPIs. Review under Proposed and add to Drafts.`)
+      navigate('/kpi-draft', { state: { drafts: [], proposals: kpisResp, selectedTables: selected } })
     } catch (error) {
       console.error('Failed to analyze tables:', error)
       toast('error', 'Failed to analyze tables. Please try again.')


### PR DESCRIPTION
Route generated KPIs to 'Proposed KPIs' section instead of 'All Draft KPIs' to allow user review before drafting.

The original implementation directly added newly generated KPIs to the 'All Draft KPIs' section. This change introduces an intermediate 'Proposed KPIs' stage, giving users the opportunity to review and selectively add KPIs to their drafts, improving the workflow and user control.

---
<a href="https://cursor.com/background-agent?bcId=bc-7faaf510-2e22-4efc-bf45-34fca28b7a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7faaf510-2e22-4efc-bf45-34fca28b7a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

