### PR TITLE
Generate and save thought graph to BQ

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -49,6 +49,8 @@ class GenerateKpisRequest(BaseModel):
 	tables: List[TableRef]
 	k: Optional[int] = 5
 	prefer_cross: Optional[bool] = False
+	thought_graph_id: Optional[str] = None
+	thought_graph: Optional[Dict[str, Any]] = None
 
 
 class KPIItem(BaseModel):
@@ -182,3 +184,88 @@ class AnalystChatRequest(BaseModel):
 class AnalystChatResponse(BaseModel):
 	reply: str
 	kpis: Optional[List[KPIItem]] = None
+
+
+# Thought Graphs
+class ThoughtGraphNode(BaseModel):
+	id: str
+	type: str
+	label: Optional[str] = None
+
+
+class ThoughtGraphEdge(BaseModel):
+	source: str
+	target: str
+	type: str
+
+
+class ThoughtGraphJoinPair(BaseModel):
+	left: str
+	right: str
+
+
+class ThoughtGraphJoin(BaseModel):
+	id: Optional[str] = None
+	left_table: Optional[str] = None
+	right_table: Optional[str] = None
+	type: Optional[str] = None
+	on: Optional[str] = None
+	pairs: Optional[List[ThoughtGraphJoinPair]] = None
+
+
+class ThoughtGraphPayload(BaseModel):
+	graph: Dict[str, Any]
+	joins: Optional[List[ThoughtGraphJoin]] = None
+
+
+class ThoughtGraphSaveRequest(BaseModel):
+	id: Optional[str] = None
+	name: str
+	primary_dataset_id: Optional[str] = None
+	datasets: Optional[List[str]] = None
+	selected_tables: List[TableRef]
+	graph: Dict[str, Any]
+
+
+class ThoughtGraphSaveResponse(BaseModel):
+	id: str
+	name: str
+	version: str
+
+
+class ThoughtGraphListItem(BaseModel):
+	id: str
+	name: str
+	version: Optional[str] = None
+	primary_dataset_id: Optional[str] = None
+	datasets: Optional[List[str]] = None
+	created_at: Optional[str] = None
+	updated_at: Optional[str] = None
+
+
+class ThoughtGraphListResponse(BaseModel):
+	graphs: List[ThoughtGraphListItem]
+
+
+class ThoughtGraphGetResponse(BaseModel):
+	id: str
+	name: str
+	version: Optional[str] = None
+	primary_dataset_id: Optional[str] = None
+	datasets: Optional[List[str]] = None
+	selected_tables: List[TableRef]
+	graph: Dict[str, Any]
+	created_at: Optional[str] = None
+	updated_at: Optional[str] = None
+
+
+class ThoughtGraphGenerateRequest(BaseModel):
+	tables: List[TableRef]
+	datasets: Optional[List[str]] = None
+	name: Optional[str] = None
+	prompt: Optional[str] = None
+
+
+class ThoughtGraphGenerateResponse(BaseModel):
+	graph: Dict[str, Any]
+	name: str

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,14 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './pages/App'
 import Home from './pages/Home'
 import KPIDraft from './pages/KPIDraft'
+import ThoughtGraphPage from './pages/ThoughtGraph'
 
 const router = createBrowserRouter([
   { path: '/', element: <Home /> },
   { path: '/editor', element: <App /> },
   { path: '/editor/:id', element: <App /> },
   { path: '/kpi-draft', element: <KPIDraft /> },
+  { path: '/thought-graph', element: <ThoughtGraphPage /> },
 ])
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -13,6 +13,7 @@ import { KPICatalog } from '../ui/KPICatalog'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { LineageGraph } from '../ui/LineageGraph'
+import { ThoughtGraphPicker } from '../ui/ThoughtGraphPicker'
 
 export default function App() {
   const params = useParams()
@@ -726,6 +727,14 @@ export default function App() {
                     {datasets.filter(ds => !ds.isBackendCreated).length} of {datasets.length} datasets available
                   </div>
                   <TableSelector datasets={datasets} onChange={setSelected} />
+                  {/* Thought Graph actions */}
+                  <div className="toolbar" style={{ marginTop: 8, gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <button className="btn" disabled={!selected.length} onClick={() => {
+                      try { sessionStorage.setItem('thoughtGraph', JSON.stringify({ selectedTables: selected })) } catch {}
+                      navigate('/thought-graph', { state: { selectedTables: selected } })
+                    }}>Generate Thought Graph</button>
+                    <ThoughtGraphPicker selected={selected} />
+                  </div>
                 </>
               )}
               <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>

--- a/frontend/src/pages/ThoughtGraph.tsx
+++ b/frontend/src/pages/ThoughtGraph.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { api } from '../services/api'
+import { LineageGraph } from '../ui/LineageGraph'
+
+type TableRef = { datasetId: string; tableId: string }
+
+export default function ThoughtGraphPage() {
+	const navigate = useNavigate()
+	const location = useLocation() as any
+	const initial = (location && (location.state as any)) || {}
+	const [name, setName] = useState<string>(initial?.name || 'Thought Graph')
+	const [selectedTables, setSelectedTables] = useState<TableRef[]>(() => {
+		try {
+			if (Array.isArray(initial?.selectedTables)) return initial.selectedTables
+			const saved = sessionStorage.getItem('thoughtGraph')
+			if (!saved) return []
+			const parsed = JSON.parse(saved)
+			return Array.isArray(parsed?.selectedTables) ? parsed.selectedTables : []
+		} catch { return [] }
+	})
+	const [graph, setGraph] = useState<{ graph: { nodes: any[]; edges: any[] }; joins?: any[] }>(() => {
+		try {
+			if (initial?.graph) return initial.graph
+			const saved = sessionStorage.getItem('thoughtGraph')
+			if (!saved) return { graph: { nodes: [], edges: [] }, joins: [] }
+			const parsed = JSON.parse(saved)
+			return parsed?.graph || { graph: { nodes: [], edges: [] }, joins: [] }
+		} catch { return { graph: { nodes: [], edges: [] }, joins: [] } }
+	})
+	const [loading, setLoading] = useState<boolean>(false)
+	const [saving, setSaving] = useState<boolean>(false)
+	const [datasetId, setDatasetId] = useState<string>(initial?.primary_dataset_id || '')
+	const [datasets, setDatasets] = useState<any[]>([])
+	const [graphsForDataset, setGraphsForDataset] = useState<any[]>([])
+	const [selectedGraphId, setSelectedGraphId] = useState<string>('')
+
+	useEffect(() => {
+		api.getDatasets().then(setDatasets).catch(()=>{})
+	}, [])
+
+	useEffect(() => {
+		try {
+			sessionStorage.setItem('thoughtGraph', JSON.stringify({ name, selectedTables, graph }))
+		} catch {}
+	}, [name, selectedTables, graph])
+
+	useEffect(() => {
+		if (!datasetId) { setGraphsForDataset([]); return }
+		api.listThoughtGraphs(datasetId).then(setGraphsForDataset).catch(()=>setGraphsForDataset([]))
+	}, [datasetId])
+
+	async function generateDraft() {
+		if (!selectedTables.length) return
+		setLoading(true)
+		try {
+			const res = await api.generateThoughtGraph(selectedTables, name)
+			setGraph(res.graph)
+		} finally { setLoading(false) }
+	}
+
+	async function saveGraph() {
+		setSaving(true)
+		try {
+			const res = await api.saveThoughtGraph({ name, primary_dataset_id: datasetId || (selectedTables[0]?.datasetId || ''), datasets: Array.from(new Set(selectedTables.map(t=>t.datasetId))), selected_tables: selectedTables, graph })
+			setSelectedGraphId(res.id)
+			alert(`Saved Thought Graph ${res.name} v${res.version}`)
+		} catch (e:any) {
+			alert(`Failed to save: ${String(e?.response?.data?.detail || e?.message || e)}`)
+		} finally { setSaving(false) }
+	}
+
+	function addNodeFromTable(t: TableRef) {
+		const fq = `${initial?.projectId || ''}.${t.datasetId}.${t.tableId}`
+		setGraph(prev => ({ ...prev, graph: { nodes: [...(prev.graph?.nodes || []), { id: fq, type: 'table', label: t.tableId }], edges: prev.graph?.edges || [] } }))
+	}
+
+	function removeNode(id: string) {
+		setGraph(prev => ({ ...prev, graph: { nodes: (prev.graph?.nodes || []).filter((n:any)=>n.id!==id), edges: (prev.graph?.edges || []).filter((e:any)=> e.source!==id && e.target!==id) } }))
+	}
+
+	function addJoin(leftFq: string, rightFq: string) {
+		setGraph(prev => ({ ...prev, joins: [ ...(prev.joins || []), { left_table: leftFq, right_table: rightFq, type: 'JOIN' } ] }))
+	}
+
+	const tablesInDataset = useMemo(() => {
+		if (!datasetId) return []
+		return selectedTables.filter(t => t.datasetId === datasetId)
+	}, [datasetId, selectedTables])
+
+	return (
+		<div className="app-grid" style={{ gridTemplateColumns: 'var(--sidebar-w, 320px) 1fr' }}>
+			<div className="sidebar" style={{ display: 'grid', gap: 12 }}>
+				<div className="panel">
+					<div className="section-title">Thought Graph</div>
+					<div className="toolbar" style={{ gap: 8 }}>
+						<input className="input" placeholder="Name" value={name} onChange={e=>setName(e.target.value)} />
+						<button className="btn" onClick={() => navigate(-1)}>Back</button>
+					</div>
+				</div>
+				<div className="panel">
+					<div className="section-title">Dataset</div>
+					<select className="select" value={datasetId} onChange={e=>setDatasetId(e.target.value)}>
+						<option value="">Select dataset…</option>
+						{datasets.map((d:any)=> (<option key={d.datasetId} value={d.datasetId}>{d.datasetId}</option>))}
+					</select>
+					{datasetId && (
+						<div style={{ marginTop: 8 }}>
+							<div className="card-subtitle">Existing Thought Graphs</div>
+							<select className="select" value={selectedGraphId} onChange={async e => {
+								const id = e.target.value
+								setSelectedGraphId(id)
+								if (!id) return
+								try {
+									const full = await api.getThoughtGraph(id)
+									setName(full.name)
+									setSelectedTables(full.selected_tables || [])
+									setGraph(full.graph)
+								} catch {}
+							}}>
+								<option value="">Select existing…</option>
+								{graphsForDataset.map((g:any)=> (<option key={g.id} value={g.id}>{g.name} (v{g.version})</option>))}
+							</select>
+						</div>
+					)}
+				</div>
+				<div className="panel">
+					<div className="section-title">Selected Tables</div>
+					<div className="card-subtitle">Add/remove nodes and define joins.</div>
+					<div className="scroll">
+						{selectedTables.map((t, idx) => (
+							<div key={`${t.datasetId}.${t.tableId}.${idx}`} className="list-item">
+								<div style={{ flex: 1 }}>{t.datasetId}.{t.tableId}</div>
+								<div className="toolbar">
+									<button className="btn btn-sm" onClick={() => addNodeFromTable(t)}>Add Node</button>
+								</div>
+							</div>
+						))}
+					</div>
+					<div className="toolbar" style={{ marginTop: 8 }}>
+						<button className="btn" onClick={generateDraft} disabled={!selectedTables.length || loading}>{loading ? 'Generating…':'Regenerate'}</button>
+						<button className="btn btn-primary" onClick={saveGraph} disabled={saving}>{saving ? 'Saving…':'Publish'}</button>
+					</div>
+				</div>
+			</div>
+			<div className="panel" style={{ margin: 0, padding: 0, overflow: 'hidden' }}>
+				<div style={{ height: '70vh' }}>
+					<LineageGraph graph={graph.graph || { nodes: [], edges: [] }} joins={graph.joins || []} />
+				</div>
+				<div style={{ borderTop: '1px solid var(--border)', padding: 12 }}>
+					<div className="toolbar" style={{ gap: 8, flexWrap: 'wrap' }}>
+						<input className="input" placeholder="Left table FQN" id="__left" />
+						<input className="input" placeholder="Right table FQN" id="__right" />
+						<button className="btn btn-sm" onClick={() => {
+							const l = (document.getElementById('__left') as HTMLInputElement)?.value?.trim()
+							const r = (document.getElementById('__right') as HTMLInputElement)?.value?.trim()
+							if (l && r) addJoin(l, r)
+						}}>Add Join</button>
+						<input className="input" placeholder="Node id to remove" id="__rm" />
+						<button className="btn btn-sm" onClick={() => {
+							const id = (document.getElementById('__rm') as HTMLInputElement)?.value?.trim()
+							if (id) removeNode(id)
+						}}>Remove Node</button>
+					</div>
+					<div className="card-subtitle" style={{ marginTop: 8 }}>Changes stay local until Publish. Use Regenerate to draft again.</div>
+				</div>
+			</div>
+		</div>
+	)
+}
+

--- a/frontend/src/ui/ThoughtGraphPicker.tsx
+++ b/frontend/src/ui/ThoughtGraphPicker.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { api } from '../services/api'
+
+type TableRef = { datasetId: string; tableId: string }
+
+export function ThoughtGraphPicker({ selected }: { selected: TableRef[] }) {
+	const datasetIds = useMemo(() => Array.from(new Set(selected.map(s => s.datasetId))), [selected])
+	const [options, setOptions] = useState<{ id: string; name: string; version?: string; primary_dataset_id?: string }[]>([])
+	const [value, setValue] = useState<string>('')
+
+	useEffect(() => {
+		if (datasetIds.length !== 1) { setOptions([]); setValue(''); return }
+		api.listThoughtGraphs(datasetIds[0]).then(setOptions).catch(()=>{ setOptions([]) })
+	}, [datasetIds.join('|')])
+
+	if (datasetIds.length !== 1) return (
+		<div className="card-subtitle">Select one dataset to pick a Thought Graph</div>
+	)
+
+	return (
+		<div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+			<select className="select" value={value} onChange={e => setValue(e.target.value)}>
+				<option value="">Select Thought Graph…</option>
+				{options.map(o => (<option key={o.id} value={o.id}>{o.name} (v{o.version})</option>))}
+			</select>
+		</div>
+	)
+}
+


### PR DESCRIPTION
Add Thought Graph feature to allow users to define data relationships and provide context for AI-driven KPI generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4e936dc-8a48-4887-a489-39117a1da1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4e936dc-8a48-4887-a489-39117a1da1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

